### PR TITLE
Add support for Python 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Python versions](https://img.shields.io/pypi/pyversions/aiometer.svg)
 [![Package version](https://badge.fury.io/py/aiometer.svg)](https://pypi.org/project/aiometer)
 
-`aiometer` is a Python 3.8+ concurrency scheduling library compatible with `asyncio` and `trio` and inspired by [Trimeter](https://github.com/python-trio/trimeter). It makes it easier to execute lots of tasks concurrently while controlling concurrency limits (i.e. applying _[backpressure](https://lucumr.pocoo.org/2020/1/1/async-pressure/)_) and collecting results in a predictable manner.
+`aiometer` is a Python 3.7+ concurrency scheduling library compatible with `asyncio` and `trio` and inspired by [Trimeter](https://github.com/python-trio/trimeter). It makes it easier to execute lots of tasks concurrently while controlling concurrency limits (i.e. applying _[backpressure](https://lucumr.pocoo.org/2020/1/1/async-pressure/)_) and collecting results in a predictable manner.
 
 _This project is currently in early alpha. Be sure to pin any dependencies to the latest minor._
 

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -12,12 +12,23 @@ jobs:
   - job: Check
     steps:
       - template: templates/install.yml
+        parameters:
+          pythonVersion: "3.7"
       - script: scripts/check
         displayName: "Run checks"
 
   - job: Test
+    strategy:
+      matrix:
+        Python37:
+          pythonVersion: "3.7"
+        Python38:
+          pythonVersion: "3.8"
+
     steps:
       - template: templates/install.yml
+        parameters:
+          pythonVersion: $(pythonVersion)
       - script: scripts/test
         displayName: "Run tests"
       - script: |

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -9,14 +9,6 @@ variables:
   PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
 
 jobs:
-  - job: Check
-    steps:
-      - template: templates/install.yml
-        parameters:
-          pythonVersion: "3.7"
-      - script: scripts/check
-        displayName: "Run checks"
-
   - job: Test
     strategy:
       matrix:
@@ -29,6 +21,8 @@ jobs:
       - template: templates/install.yml
         parameters:
           pythonVersion: $(pythonVersion)
+      - script: scripts/check
+        displayName: "Run checks"
       - script: scripts/test
         displayName: "Run tests"
       - script: |

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -32,9 +32,9 @@ jobs:
       - script: scripts/test
         displayName: "Run tests"
       - script: |
-          if [ -f .coverage ]; then
-          python -m pip install codecov;
-          codecov --required;
+          if [ $(pythonVersion) = '3.8' ] & [ -f .coverage ]; then
+            python -m pip install codecov;
+            codecov --required;
           fi
         env:
           CODECOV_TOKEN: $(codecovToken)

--- a/ci/templates/install.yml
+++ b/ci/templates/install.yml
@@ -1,8 +1,12 @@
+parameters:
+  - name: pythonVersion
+    type: string
+
 steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: "3.8"
-    displayName: "Use Python"
+      versionSpec: "${{ parameters.pythonVersion }}"
+    displayName: "Use Python ${{ parameters.pythonVersion }}"
 
   - task: Cache@2
     inputs:

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,8 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,
-    install_requires=["anyio==1.*"],
-    python_requires=">=3.8",
+    install_requires=["anyio==1.*", "typing-extensions==3.7.*; python_version<'3.8'"],
+    python_requires=">=3.7",
     license="MIT",
     classifiers=[
         "Development Status :: 3 - Alpha",
@@ -42,6 +42,8 @@ setup(
         "Framework :: AsyncIO",
         "Framework :: Trio",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],
 )

--- a/src/aiometer/_impl/_amap.py
+++ b/src/aiometer/_impl/_amap.py
@@ -18,9 +18,9 @@ from ._run_on_each import run_on_each
 from ._types import T, U
 
 try:
-    from typing import Literal
+    from typing_extensions import Literal  # Python 3.7.
 except ImportError:  # pragma: no cover
-    from typing_extensions import Literal  # type: ignore
+    from typing import Literal  # type: ignore
 
 
 @overload

--- a/src/aiometer/_impl/_amap.py
+++ b/src/aiometer/_impl/_amap.py
@@ -6,7 +6,6 @@ from typing import (
     AsyncIterator,
     Awaitable,
     Callable,
-    Literal,
     Sequence,
     Tuple,
     overload,
@@ -17,6 +16,11 @@ import anyio
 from .._concurrency import open_memory_channel
 from ._run_on_each import run_on_each
 from ._types import T, U
+
+try:
+    from typing import Literal
+except ImportError:  # pragma: no cover
+    from typing_extensions import Literal  # type: ignore
 
 
 @overload

--- a/tests/test_aiometer.py
+++ b/tests/test_aiometer.py
@@ -72,7 +72,7 @@ class TestRunners:
         with pytest.raises(Failure):
             async with aiometer.amap(process, items) as results:
                 async for result in results:
-                    pass
+                    pass  # pragma: no cover  # Python 3.7 fix.
 
     async def test_run_any(self) -> None:
         async def process_fast() -> str:
@@ -136,7 +136,7 @@ class TestMaxAtOnce:
             spy.process, spy.build_args(), max_at_once=max_at_once
         ) as results:
             async for _ in results:
-                pass
+                pass  # pragma: no cover  # Python 3.7 fix.
 
         spy.assert_max_tasks_respected(max_at_once)
 
@@ -212,7 +212,7 @@ class TestMaxPerSecond:
                 spy.process, spy.build_args(), max_per_second=max_per_second
             ) as results:
                 async for _ in results:
-                    pass
+                    pass  # pragma: no cover  # Python 3.7 fix.
 
     @pytest.mark.parametrize("max_per_second", values)
     async def test_run_any(self, max_per_second: float) -> None:


### PR DESCRIPTION
- Ensure `typing-extensions` is installed to be able to use `typing.Literal`.
- Add Python 3.7 to CI.