### PR TITLE
Switch to generic cell rate algorithm (GCRA) for `max_per_second`

### DIFF
--- a/src/aiometer/_impl/_run_on_each.py
+++ b/src/aiometer/_impl/_run_on_each.py
@@ -3,7 +3,7 @@ from typing import Any, Awaitable, Callable, List, NamedTuple, Optional, Sequenc
 import anyio
 
 from .._concurrency import MemorySendChannel
-from ._meters import MaxAtOnceMeter, Meter, MeterState, TokenBucketMeter
+from ._meters import MaxAtOnceMeter, Meter, MeterState, RateLimitMeter
 from ._types import T, U
 
 
@@ -41,7 +41,7 @@ async def run_on_each(
     if max_at_once is not None:
         meters.append(MaxAtOnceMeter(max_at_once))
     if max_per_second is not None:
-        meters.append(TokenBucketMeter(max_per_second))
+        meters.append(RateLimitMeter(max_per_second))
 
     meter_states = [await meter.new_state() for meter in meters]
 

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -1,0 +1,11 @@
+import itertools
+from typing import Iterable, Iterator, Tuple, TypeVar
+
+T = TypeVar("T")
+
+
+def pairwise(iterable: Iterable[T]) -> Iterator[Tuple[T, T]]:
+    """s -> (s0, s1), (s1, s2), (s2, s3), ..."""
+    a, b = itertools.tee(iterable)
+    next(b, None)
+    return zip(a, b)

--- a/tests/test_aiometer.py
+++ b/tests/test_aiometer.py
@@ -1,12 +1,13 @@
 import random
-import time
 from contextlib import asynccontextmanager
-from typing import Any, AsyncIterator, Awaitable, Callable, List
+from typing import Any, AsyncIterator, List
 
 import anyio
 import pytest
 
 import aiometer
+
+from ._utils import pairwise
 
 
 @pytest.mark.anyio
@@ -158,63 +159,50 @@ class TestMaxAtOnce:
 @pytest.mark.anyio
 class TestMaxPerSecond:
     class _Spy:
-        def __init__(self, num_tasks: int, task: Callable[[], Awaitable[None]]) -> None:
-            self.num_tasks = num_tasks
-            self.task = task
-            self.num_started = 0
-            self.start = time.time()
+        def __init__(self, num_tasks: int) -> None:
+            self.tasks = [self.task for _ in range(num_tasks)]
+            self.args = [None for _ in range(num_tasks)]
+            self.start_times: List[float] = []
 
-        def build_args(self) -> List[None]:
-            return [None for _ in range(self.num_tasks)]
+        async def task(self, *args: Any) -> None:
+            time = await anyio.current_time()
+            self.start_times.append(time)
 
-        def build_tasks(self) -> list:
-            return [self.process for _ in range(self.num_tasks)]
+        @property
+        def max_task_delta(self) -> float:
+            return max(t2 - t1 for t1, t2 in pairwise(self.start_times))
 
-        async def process(self, *args: Any) -> None:
-            self.num_started += 1
-            await self.task()
-
-    values = [1, 2, 5, 10, 25, 100]
+    max_per_second_params = [5, 10, 20, 30, 40, 50, 70, 100]
 
     @asynccontextmanager
     async def create_spy(self, max_per_second: float) -> AsyncIterator["_Spy"]:
-        # Simplest would be to look at how many tasks have started within 1 second,
-        # but tests would then be too slow.
-        # So, scale this down (but not too much)...
-        task_seconds = 0.1
-        # ...and take it into account to run more tasks:
-        num_tasks = int(max(self.values) / task_seconds)
+        spy = self._Spy(num_tasks=3)
+        yield spy
+        period = 1 / max_per_second
+        assert spy.max_task_delta == pytest.approx(period, rel=0.75)
 
-        spy = self._Spy(num_tasks=num_tasks, task=lambda: anyio.sleep(task_seconds))
-        wait = task_seconds * 1.1  # Give it a better chance to spawn all tasks.
-        async with anyio.move_on_after(wait):
-            yield spy
-
-        expected_num_started = max(1, round(task_seconds * max_per_second))
-        assert spy.num_started == pytest.approx(expected_num_started, abs=1)
-
-    @pytest.mark.parametrize("max_per_second", values)
+    @pytest.mark.parametrize("max_per_second", max_per_second_params)
     async def test_run_on_each(self, max_per_second: float) -> None:
         async with self.create_spy(max_per_second) as spy:
             await aiometer.run_on_each(
-                spy.process, spy.build_args(), max_per_second=max_per_second
+                spy.task, spy.args, max_per_second=max_per_second
             )
 
-    @pytest.mark.parametrize("max_per_second", values)
+    @pytest.mark.parametrize("max_per_second", max_per_second_params)
     async def test_run_all(self, max_per_second: float) -> None:
         async with self.create_spy(max_per_second) as spy:
-            await aiometer.run_all(spy.build_tasks(), max_per_second=max_per_second)
+            await aiometer.run_all(spy.tasks, max_per_second=max_per_second)
 
-    @pytest.mark.parametrize("max_per_second", values)
+    @pytest.mark.parametrize("max_per_second", max_per_second_params)
     async def test_amap(self, max_per_second: float) -> None:
         async with self.create_spy(max_per_second) as spy:
             async with aiometer.amap(
-                spy.process, spy.build_args(), max_per_second=max_per_second
+                spy.task, spy.args, max_per_second=max_per_second
             ) as results:
                 async for _ in results:
                     pass  # pragma: no cover  # Python 3.7 fix.
 
-    @pytest.mark.parametrize("max_per_second", values)
+    @pytest.mark.parametrize("max_per_second", max_per_second_params)
     async def test_run_any(self, max_per_second: float) -> None:
         async with self.create_spy(max_per_second) as spy:
-            await aiometer.run_any(spy.build_tasks(), max_per_second=max_per_second)
+            await aiometer.run_any(spy.tasks, max_per_second=max_per_second)


### PR DESCRIPTION
As suggested by @pgjones [on Twitter](https://twitter.com/pdgjones/status/1241495363753840644?s=20) 😄 

Used thes resources for the implementation:

- https://gitlab.com/pgjones/quart-rate-limiter/-/blob/master/src/quart_rate_limiter/__init__.py#L252-282
- https://en.wikipedia.org/wiki/Generic_cell_rate_algorithm#Virtual_scheduling_description

Also found a way to make tests for `max_per_second` much simpler/more reliable.