### PR TITLE
Tweak CI

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -9,6 +9,12 @@ variables:
   PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
 
 jobs:
+  - job: Check
+    steps:
+      - template: templates/install.yml
+        parameters:
+          pythonVersion: "3.8"
+
   - job: Test
     strategy:
       matrix:
@@ -16,20 +22,20 @@ jobs:
           pythonVersion: "3.7"
         Python38:
           pythonVersion: "3.8"
+          uploadCoverage: true
 
     steps:
       - template: templates/install.yml
         parameters:
           pythonVersion: $(pythonVersion)
-      - script: scripts/check
-        displayName: "Run checks"
       - script: scripts/test
         displayName: "Run tests"
       - script: |
-          if [ $(pythonVersion) = '3.8' ] & [ -f .coverage ]; then
+          if [ -f .coverage ]; then
             python -m pip install codecov;
             codecov --required;
           fi
+        condition: eq(variables['uploadCoverage'], true)
         env:
           CODECOV_TOKEN: $(codecovToken)
         displayName: "Upload coverage"


### PR DESCRIPTION
- Run checks in a separate job.
- Only upload coverage on one Python version.