### PR TITLE
Migrate to release-on-tag

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -8,24 +8,36 @@ resources:
 
 trigger:
   - master
+  - refs/tags/*
 
 pr:
   - master
 
 variables:
-  CI: true
-  PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
+  - name: CI
+    value: true
+  - name: PIP_CACHE_DIR
+    value: $(Pipeline.Workspace)/.cache/pip
+  - group: pypi-credentials
 
-jobs:
-  - template: job--python-check.yml@templates
-    parameters:
-      pythonVersion: "3.9"
+stages:
+  - stage: test
+    jobs:
+      - template: job--python-check.yml@templates
+        parameters:
+          pythonVersion: "3.9"
+      - template: job--python-test.yml@templates
+        parameters:
+          jobs:
+            py36: null
+            py37: null
+            py38: null
+            py39:
+              coverage: true
 
-  - template: job--python-test.yml@templates
-    parameters:
-      jobs:
-        py36: null
-        py37: null
-        py38: null
-        py39:
-          coverage: true
+  - stage: publish
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+    jobs:
+      - template: job--python-publish.yml@templates
+        parameters:
+          token: $(pypiToken)

--- a/scripts/build
+++ b/scripts/build
@@ -1,0 +1,10 @@
+#!/bin/sh -e
+
+PREFIX=""
+if [ -d "venv" ] ; then
+    PREFIX="venv/bin/"
+fi
+
+${PREFIX}python setup.py sdist bdist_wheel
+${PREFIX}twine check dist/*
+rm -r build

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,31 +1,18 @@
 #!/bin/sh -e
 
-export PACKAGE="aiometer"
-export VERSION=`cat src/${PACKAGE}/__version__.py | grep __version__ | sed "s/__version__ = //" | sed "s/'//g"`
-export PREFIX=""
-if [ -d 'venv' ] ; then
-    export PREFIX="venv/bin/"
+VERSION_FILE="src/aiometer/__version__.py"
+PREFIX=""
+if [ -d "venv" ] ; then
+    PREFIX="venv/bin/"
 fi
 
-if ! command -v "${PREFIX}twine" &>/dev/null ; then
-    echo "Unable to find the 'twine' command."
-    echo "Install from PyPI, using '${PREFIX}pip install twine'."
-    exit 1
+if [ ! -z "$CI" ]; then 
+    VERSION=$(grep __version__ ${VERSION_FILE} | grep -o '[0-9][^"]*')
+
+    if [ "refs/tags/${VERSION}" != "${GIT_REF}" ] ; then
+        echo "Git ref '${GIT_REF}' did not match package version '${VERSION}'"
+        exit 1
+    fi
 fi
 
-if ! ${PREFIX}pip show wheel &>/dev/null ; then
-    echo "Unable to find the 'wheel' command."
-    echo "Install from PyPI, using '${PREFIX}pip install wheel'."
-    exit 1
-fi
-
-scripts/clean
-
-${PREFIX}python setup.py sdist bdist_wheel
-${PREFIX}twine upload dist/*
-
-echo "You probably want to also tag the version now:"
-echo "git tag -a ${VERSION} -m 'version ${VERSION}'"
-echo "git push --tags"
-
-scripts/clean
+${PREFIX}twine upload "$@" dist/*


### PR DESCRIPTION
I pushed tag `0.3.0` and associated release assuming it would auto-release to PyPI like for some other packages (asgi-lifespan, arel, etc), but the tooling is not in place yet. This PR moves to using the publish stage AZP template.