### PR TITLE
Fix `ValueError: max() arg is an empty sequence`

### DIFF
--- a/src/aiometer/_impl/utils.py
+++ b/src/aiometer/_impl/utils.py
@@ -9,7 +9,7 @@ def list_from_indexed_dict(dct: Mapping[int, T]) -> List[T]:
     """
     Given `{0: 'v_0', ..., n: 'v_N'}`, return `['v_0', ... 'v_n']`.
     """
-    return [dct[index] for index in range(max(dct) + 1)]
+    return [dct[index] for index in range(max(dct) + 1)] if dct else []
 
 
 def check_strictly_positive(name: str, value: float) -> None:


### PR DESCRIPTION
Sometimes in this function : 

https://github.com/florimondmanca/aiometer/blob/17c8b70ce02838927f7f97bb7510c30e9f731e78/src/aiometer/_impl/utils.py#L8-L12

The `dct` param is `{}`, so the `max(dct)` throws a `ValueError: max() arg is an empty sequence`.
I just added a check before calling `max()`.