### PR TITLE
chore: relax typing-extensions version specifier

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ black==21.6b0
 flake8
 isort==5.*
 mypy
-pytest
+pytest==6.2.5
 pytest-cov
 seed-isort-config
-trio
+trio>=0.16,<0.22

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     zip_safe=False,
     install_requires=[
         "anyio~=3.2",
-        "typing-extensions~=3.10; python_version<'3.8'",
+        "typing-extensions>=3.10,<5.0; python_version<'3.8'",
         "contextlib2>=21.6.0; python_version<'3.7'",
     ],
     python_requires=">=3.6",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture(
+    params=[
+        pytest.param("asyncio"),
+        pytest.param("trio"),
+    ]
+)
+def anyio_backend(request):
+    return request.param


### PR DESCRIPTION
Relax `typing-extensions` version specifier to support `typing-extensions` v4. (#31)

I use a library which relies on `typing-extensions` v4 and it will be great if `aiometer` allows to use that. 
(I tested with `typing-extensions` v4 and there is no issue)