### PR TITLE
fix: fix wrong type hints

### DIFF
--- a/src/aiometer/_impl/amap.py
+++ b/src/aiometer/_impl/amap.py
@@ -6,10 +6,10 @@ from typing import (
     AsyncIterator,
     Awaitable,
     Callable,
+    Optional,
     Sequence,
     Tuple,
     overload,
-    Optional
 )
 
 import anyio

--- a/src/aiometer/_impl/amap.py
+++ b/src/aiometer/_impl/amap.py
@@ -9,6 +9,7 @@ from typing import (
     Sequence,
     Tuple,
     overload,
+    Optional
 )
 
 import anyio
@@ -32,8 +33,8 @@ def amap(
     async_fn: Callable[[T], Awaitable[U]],
     args: Sequence[T],
     *,
-    max_at_once: int = None,
-    max_per_second: float = None,
+    max_at_once: Optional[int] = None,
+    max_per_second: Optional[float] = None,
     _include_index: Literal[False] = False,
 ) -> AsyncContextManager[AsyncIterable[U]]:
     ...  # pragma: no cover
@@ -44,8 +45,8 @@ def amap(
     async_fn: Callable[[T], Awaitable[U]],
     args: Sequence[T],
     *,
-    max_at_once: int = None,
-    max_per_second: float = None,
+    max_at_once: Optional[int] = None,
+    max_per_second: Optional[float] = None,
     _include_index: Literal[True],
 ) -> AsyncContextManager[AsyncIterable[Tuple[int, U]]]:
     ...  # pragma: no cover
@@ -58,8 +59,8 @@ def amap(
     async_fn: Callable[[Any], Awaitable],
     args: Sequence,
     *,
-    max_at_once: int = None,
-    max_per_second: float = None,
+    max_at_once: Optional[int] = None,
+    max_per_second: Optional[float] = None,
     _include_index: bool = False,
 ) -> AsyncContextManager[AsyncIterable]:
     @asynccontextmanager

--- a/src/aiometer/_impl/run_all.py
+++ b/src/aiometer/_impl/run_all.py
@@ -1,4 +1,4 @@
-from typing import Awaitable, Callable, Dict, List, Sequence
+from typing import Awaitable, Callable, Dict, List, Sequence, Optional
 
 from .amap import amap
 from .types import T
@@ -8,8 +8,8 @@ from .utils import check_no_lambdas, list_from_indexed_dict
 async def run_all(
     async_fns: Sequence[Callable[[], Awaitable[T]]],
     *,
-    max_at_once: int = None,
-    max_per_second: float = None,
+    max_at_once: Optional[int] = None,
+    max_per_second: Optional[float] = None,
 ) -> List[T]:
     check_no_lambdas(async_fns, entrypoint="aiometer.run_all")
 

--- a/src/aiometer/_impl/run_all.py
+++ b/src/aiometer/_impl/run_all.py
@@ -1,4 +1,4 @@
-from typing import Awaitable, Callable, Dict, List, Sequence, Optional
+from typing import Awaitable, Callable, Dict, List, Optional, Sequence
 
 from .amap import amap
 from .types import T

--- a/src/aiometer/_impl/run_any.py
+++ b/src/aiometer/_impl/run_any.py
@@ -1,4 +1,4 @@
-from typing import Awaitable, Callable, Sequence, Optional
+from typing import Awaitable, Callable, Optional, Sequence
 
 from .amap import amap
 from .types import T

--- a/src/aiometer/_impl/run_any.py
+++ b/src/aiometer/_impl/run_any.py
@@ -1,4 +1,4 @@
-from typing import Awaitable, Callable, Sequence
+from typing import Awaitable, Callable, Sequence, Optional
 
 from .amap import amap
 from .types import T
@@ -8,8 +8,8 @@ from .utils import check_no_lambdas
 async def run_any(
     async_fns: Sequence[Callable[[], Awaitable[T]]],
     *,
-    max_at_once: int = None,
-    max_per_second: float = None,
+    max_at_once: Optional[int] = None,
+    max_per_second: Optional[float] = None,
 ) -> T:
     check_no_lambdas(async_fns, entrypoint="aiometer.run_any")
 

--- a/src/aiometer/_impl/run_on_each.py
+++ b/src/aiometer/_impl/run_on_each.py
@@ -31,10 +31,10 @@ async def run_on_each(
     async_fn: Callable[[T], Awaitable],
     args: Sequence[T],
     *,
-    max_at_once: int = None,
-    max_per_second: float = None,
+    max_at_once: Optional[int] = None,
+    max_per_second: Optional[float] = None,
     _include_index: bool = False,
-    _send_to: MemoryObjectSendStream = None,
+    _send_to: Optional[MemoryObjectSendStream] = None,
 ) -> None:
     meters: List[Meter] = []
 


### PR DESCRIPTION
This PR addresses wrong type hints. (e.g. `max_at_once: int = None` to `max_at_once: Optional[int] = None`)