### PR TITLE
Version 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.4.0 - 2023-01-18
+
+### Removed
+
+- Drop support for Python 3.6, which has reached EOL. (Pull #38)
+
+### Added
+
+- Add official support for Python 3.10 and 3.11. (Pull #38)
+
+### Fixed
+
+- Relax version requirements for `typing_extensions` and address `mypy>=0.981` strict optional changes. (Pull #38)
+
 ## 0.3.0 - 2021-07-06
 
 ### Changed

--- a/src/aiometer/__init__.py
+++ b/src/aiometer/__init__.py
@@ -1,6 +1,6 @@
 from ._impl import amap, run_all, run_any, run_on_each
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
## 0.4.0 - 2023-01-18

### Removed

- Drop support for Python 3.6, which has reached EOL. (Pull #38)

### Added

- Add official support for Python 3.10 and 3.11. (Pull #38)

### Fixed

- Relax version requirements for `typing_extensions` and address `mypy>=0.981` strict optional changes. (Pull #38)
