### PR TITLE
Add anyio 4.x support

### DIFF
--- a/.coveragerc_py37
+++ b/.coveragerc_py37
@@ -1,0 +1,4 @@
+[report]
+exclude_lines =
+    pragma: no cover
+    pragma: nopy37

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -30,7 +30,9 @@ stages:
       - template: job--python-test.yml@templates
         parameters:
           jobs:
-            py37: null
+            py37:
+              variables:
+                PYTEST_ADDOPTS: "--cov-config=.coveragerc_py37"
             py311:
               coverage: true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-  "anyio>=3.2",
+  "anyio>=3.2,<5",
   "typing-extensions; python_version<'3.8'",
   "exceptiongroup; python_version<'3.11'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,9 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-  "anyio~=3.2",
+  "anyio>=3.2",
   "typing-extensions; python_version<'3.8'",
+  "exceptiongroup; python_version<'3.11'",
 ]
 dynamic = ["version", "readme"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 -e .
 
+# Compatibility testing.
+anyio~=3.2; python_version<'3.11'
+
 # Packaging.
 twine
 wheel

--- a/src/aiometer/_compat.py
+++ b/src/aiometer/_compat.py
@@ -1,0 +1,19 @@
+import sys
+from contextlib import contextmanager
+from typing import Generator
+
+if sys.version_info < (3, 11):  # pragma: no cover
+    from exceptiongroup import BaseExceptionGroup
+
+
+@contextmanager
+def collapse_excgroups() -> Generator[None, None, None]:
+    try:
+        yield
+    except BaseException as exc:
+        while (
+            isinstance(exc, BaseExceptionGroup) and len(exc.exceptions) == 1
+        ):  # pragma: nopy37
+            exc = exc.exceptions[0]
+
+        raise exc


### PR DESCRIPTION
Closes #42

This PR implements the compatibility code from the [anyio 3 -> 4 migration guide](
https://anyio.readthedocs.io/en/stable/migration.html#task-groups-now-wrap-single-exceptions-in-groups) to gain compatibility with anyio 4 as well retain compatibility with anyio 3.2+.

The compatibility code unwraps single-exception exception groups raised by anyio 4, so as to preserve compatibility with previous behavior: when an exception is raised by a task ran with amap(), that single exception will be raised.