### PR TITLE
Version 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.5.0 - Unreleased
+## 0.5.0 - 2023-12-11
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ _Try this code interactively using [IPython](https://ipython.org/install.html)._
 _This project is in beta and maturing. Be sure to pin any dependencies to the latest minor._
 
 ```bash
-pip install "aiometer==0.4.*"
+pip install "aiometer==0.5.*"
 ```
 
 ## Features

--- a/src/aiometer/__init__.py
+++ b/src/aiometer/__init__.py
@@ -1,6 +1,6 @@
 from ._impl import amap, run_all, run_any, run_on_each
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
## 0.5.0 - 2023-12-12

### Removed

- Drop support for Python 3.7, as it has reached EOL. (Pull #44)

### Added

- Add official support for Python 3.12. (Pull #44)
- Add support for anyio 4. This allows catching exception groups using the native ExceptionGroup. On anyio 3.2+, anyio would throw its own ExceptionGroup type. Compatibility with anyio 3.2+ is retained. (Pull #43)