### PR TITLE
Add support for asynchrous iterators for arguments

### DIFF
--- a/src/aiometer/_impl/amap.py
+++ b/src/aiometer/_impl/amap.py
@@ -1,3 +1,4 @@
+import math
 from contextlib import asynccontextmanager
 from typing import (
     Any,
@@ -10,6 +11,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    Union,
     overload,
 )
 
@@ -19,7 +21,7 @@ from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStre
 from .._compat import collapse_excgroups
 from .run_on_each import run_on_each
 from .types import T, U
-
+from .utils import as_async_iter, is_async_iter
 
 @overload
 def amap(
@@ -50,17 +52,26 @@ def amap(
 # checkers on the client side.)
 def amap(
     async_fn: Callable[[Any], Awaitable],
-    args: Sequence,
+    args: Union[Sequence,AsyncIterable],
     *,
     max_at_once: Optional[int] = None,
     max_per_second: Optional[float] = None,
     _include_index: bool = False,
 ) -> AsyncContextManager[AsyncIterable]:
+    
+    if not is_async_iter(args):
+        args = as_async_iter(args)
+
     @asynccontextmanager
     async def _amap() -> AsyncIterator[AsyncIterable]:
-        channels: Tuple[
-            MemoryObjectSendStream, MemoryObjectReceiveStream
-        ] = anyio.create_memory_object_stream(max_buffer_size=len(args))
+        try:
+            channels: Tuple[
+                MemoryObjectSendStream, MemoryObjectReceiveStream
+            ] = anyio.create_memory_object_stream(max_buffer_size=len(args))
+        except TypeError:
+            channels: Tuple[
+                MemoryObjectSendStream, MemoryObjectReceiveStream
+            ] = anyio.create_memory_object_stream(max_buffer_size=math.inf)
 
         send_channel, receive_channel = channels
 

--- a/src/aiometer/_impl/amap.py
+++ b/src/aiometer/_impl/amap.py
@@ -23,6 +23,7 @@ from .run_on_each import run_on_each
 from .types import T, U
 from .utils import as_async_iter, is_async_iter
 
+
 @overload
 def amap(
     async_fn: Callable[[T], Awaitable[U]],
@@ -52,7 +53,7 @@ def amap(
 # checkers on the client side.)
 def amap(
     async_fn: Callable[[Any], Awaitable],
-    args: Union[Sequence,AsyncIterable],
+    args: Union[Sequence, AsyncIterable],
     *,
     max_at_once: Optional[int] = None,
     max_per_second: Optional[float] = None,

--- a/src/aiometer/_impl/amap.py
+++ b/src/aiometer/_impl/amap.py
@@ -58,20 +58,11 @@ def amap(
     max_per_second: Optional[float] = None,
     _include_index: bool = False,
 ) -> AsyncContextManager[AsyncIterable]:
-    
-    if not is_async_iter(args):
-        args = as_async_iter(args)
-
     @asynccontextmanager
     async def _amap() -> AsyncIterator[AsyncIterable]:
-        try:
-            channels: Tuple[
-                MemoryObjectSendStream, MemoryObjectReceiveStream
-            ] = anyio.create_memory_object_stream(max_buffer_size=len(args))
-        except TypeError:
-            channels: Tuple[
-                MemoryObjectSendStream, MemoryObjectReceiveStream
-            ] = anyio.create_memory_object_stream(max_buffer_size=math.inf)
+        channels: Tuple[
+            MemoryObjectSendStream, MemoryObjectReceiveStream
+        ] = anyio.create_memory_object_stream(max_buffer_size=math.inf)
 
         send_channel, receive_channel = channels
 

--- a/src/aiometer/_impl/run_on_each.py
+++ b/src/aiometer/_impl/run_on_each.py
@@ -1,4 +1,13 @@
-from typing import Awaitable, Callable, List, NamedTuple, Optional, Sequence, Union, AsyncIterable
+from typing import (
+    Awaitable,
+    Callable,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Union,
+    AsyncIterable,
+)
 
 import anyio
 from anyio.streams.memory import MemoryObjectSendStream

--- a/src/aiometer/_impl/run_on_each.py
+++ b/src/aiometer/_impl/run_on_each.py
@@ -1,10 +1,11 @@
-from typing import Awaitable, Callable, List, NamedTuple, Optional, Sequence
+from typing import Awaitable, Callable, List, NamedTuple, Optional, Sequence, Union, AsyncIterable
 
 import anyio
 from anyio.streams.memory import MemoryObjectSendStream
 
 from .meters import HardLimitMeter, Meter, MeterState, RateLimitMeter
 from .types import T
+from .utils import is_async_iter, as_async_iter
 
 
 class _Config(NamedTuple):
@@ -29,7 +30,7 @@ async def _worker(
 
 async def run_on_each(
     async_fn: Callable[[T], Awaitable],
-    args: Sequence[T],
+    args: Union[Sequence[T], AsyncIterable[T]],
     *,
     max_at_once: Optional[int] = None,
     max_per_second: Optional[float] = None,
@@ -37,6 +38,9 @@ async def run_on_each(
     _send_to: Optional[MemoryObjectSendStream] = None,
 ) -> None:
     meters: List[Meter] = []
+
+    if not is_async_iter(args):
+        args = as_async_iter(args)
 
     if max_at_once is not None:
         meters.append(HardLimitMeter(max_at_once))
@@ -50,7 +54,8 @@ async def run_on_each(
     )
 
     async with anyio.create_task_group() as task_group:
-        for index, value in enumerate(args):
+        index = 0
+        async for value in args:
             for state in meter_states:
                 await state.wait_task_can_start()
 
@@ -58,3 +63,4 @@ async def run_on_each(
                 await state.notify_task_started()
 
             task_group.start_soon(_worker, async_fn, index, value, config)
+            index += 1

--- a/src/aiometer/_impl/utils.py
+++ b/src/aiometer/_impl/utils.py
@@ -66,8 +66,10 @@ def check_no_lambdas(funcs: Sequence[Callable], entrypoint: str) -> None:
 
     raise ValueError(message)
 
+
 def is_async_iter(iter) -> bool:
-    return hasattr(iter, '__aiter__')
+    return hasattr(iter, "__aiter__")
+
 
 async def as_async_iter(iter):
     for item in iter:

--- a/src/aiometer/_impl/utils.py
+++ b/src/aiometer/_impl/utils.py
@@ -65,3 +65,10 @@ def check_no_lambdas(funcs: Sequence[Callable], entrypoint: str) -> None:
     )
 
     raise ValueError(message)
+
+def is_async_iter(iter) -> bool:
+    return hasattr(iter, '__aiter__')
+
+async def as_async_iter(iter):
+    for item in iter:
+        yield item


### PR DESCRIPTION
This allows you to start processing arguments before you've generated all of them.  This was a feature trimeter had (I referenced their implementation when writing this).

This passes the existing test suite (all sync iterators) and a couple rough tests I ran using an async iterator, but could probably use a few additional automated tests.

#46 